### PR TITLE
Fix on_research_finished null reference crash

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1277,7 +1277,7 @@ do
     end)
 
     script.on_event(defines.events.on_research_finished, function(event)
-        on_something_while_open(event, cflib.on_research_finished)
+        on_something_while_open(event, cflib.on_researched_finished_while_open)
     end)
 
     setup_material_exchange_container_gui_global_events()

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "composite_factories_base",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"factorio_version": "1.1",
 	"title": "Composite Factories: Base",
 	"author": "Sopel",


### PR DESCRIPTION
## Bug: 
If a research finishes while the GUI for the Composite Factory Assembler is open, the game reports an unrecoverable error with the following error message:

```
The mod Composite Factories: Base (1.5.1) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event composite_factories_base::on_research_finished (ID 18)
__composite_factories_base__/control.lua:1077: attempt to index local 'something' (a nil value)
stack traceback:
	__composite_factories_base__/control.lua:1077: in function 'on_something_while_open'
	__composite_factories_base__/control.lua:1280: in function <__composite_factories_base__/control.lua:1279>
```

## Versions:
Factorio 1.1.104
Composite Factories 1.5.1

Reproed on a (fully updated, as of 2024-03-10) pY:AE run, in case that matters.

## STR:
1. Load the attached save 
[piano-repro2-test-compfact-151.zip](https://github.com/Sopel97/composite_factories_base/files/14559943/piano-repro2-test-compfact-151.zip) (on a pYanodon's mod pack, sorry about the size)
2. Click the Factory Crafting Station to open the gui
3. (optionally, use `/c game.speed=10` to make it trigger in a few seconds)
4. Observe crash

## Fix:
Current code registers `events.on_research_finished` to `cflib.on_research_finished`, a nil value that I was unable to find in the repo. This patch changes that to use `cflib.on_researched_finished_while_open`, which _looked like_ what is intended to be used here.

Also bumps the version because I suspect that's expected when a change is made.

Obviously I don't know this codebase, your attitudes toward the project, or even really Factorio modding, so feel free to add, remove or change anything in this PR, or close/ignore it at your leisure.